### PR TITLE
Environment variables in terraform updated

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -20,19 +20,9 @@ services:
       - ./app:/opt/gfw-mail-api/app
     depends_on:
       - redis
-      - mongo
     command: node node_modules/.bin/grunt --gruntfile app/Gruntfile.js
 
   redis:
     image: redis
     expose:
       - 6379
-
-  # mongo:
-  #   image: mongo:3.4
-  #   container_name: mail-mongo-test
-  #   command: --smallfiles
-  #   ports:
-  #     - "27017"
-  #   volumes:
-  #     - $HOME/docker/data/dataset:/data/db

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -18,19 +18,9 @@ services:
       QUEUE_URL: redis://redis
     depends_on:
       - redis
-      - mongo
     command: node node_modules/.bin/grunt --gruntfile app/Gruntfile.js e2eTest
 
   redis:
     image: redis
     expose:
       - 6379
-
-  mongo:
-    image: mongo:3.4
-    container_name: mail-mongo-test
-    command: --smallfiles
-    ports:
-      - "27017"
-    volumes:
-      - $HOME/docker/data/dataset:/data/db

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,16 +74,16 @@ data "template_file" "container_definition" {
     environment    = var.environment
     
     # Environment variables
-    port = var.container_port
-    node_path = var.node_path
-    node_env = var.node_env
-    logger_level = var.logger_level
-    suppress_no_config_warning = var.suppress_no_config_warning
-    api_gateway_url = var.api_gateway_url
-    queue_url = "redis://${data.terraform_remote_state.core.outputs.redis_replication_group_primary_endpoint_address}"
-    queue_provider = var.queue_provider
-    queue_name = var.queue_name
-    sparkpost_api_key = var.sparkpost_api_key
+    PORT = var.container_port
+    NODE_PATH = var.node_path
+    NODE_ENV = var.node_env
+    LOGGER_LEVEL = var.logger_level
+    SUPPRESS_NO_CONFIG_WARNING = var.suppress_no_config_warning
+    API_GATEWAY_URI = var.api_gateway_url
+    QUEUE_URL = "redis://${data.terraform_remote_state.core.outputs.redis_replication_group_primary_endpoint_address}"
+    QUEUE_PROVIDER = var.queue_provider
+    QUEUE_NAME = var.queue_name
+    SPARKPOST_API_KEY = var.sparkpost_api_key
 
     # Secrets
     # none


### PR DESCRIPTION
Environment variables in the terraform code were not capitalised although the Node code was expect them to be so, this has been updated.

Also removed redundant mongodb server from both docker compose files, as it was causing github actions to crash