### PR TITLE
only ever run one replica running in ECS

### DIFF
--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -1,8 +1,11 @@
 environment               = "dev"
-logger_level                 = "debug"
+logger_level              = "debug"
+
+// Only ever have one replica running, otherwise multiple emails will be sent!
+// As multiple services will subscribe to the Redis channel
 desired_count             = 1
 auto_scaling_min_capacity = 1
-auto_scaling_max_capacity = 5
+auto_scaling_max_capacity = 1
 
 container_port             = 3500
 node_path                  = "app/src"

--- a/terraform/vars/terraform-production.tfvars
+++ b/terraform/vars/terraform-production.tfvars
@@ -1,8 +1,11 @@
 environment               = "production"
-logger_level                 = "info"
-desired_count             = 2
-auto_scaling_min_capacity = 2
-auto_scaling_max_capacity = 15
+logger_level              = "info"
+
+// Only ever have one replica running, otherwise multiple emails will be sent!
+// As multiple services will subscribe to the Redis channel
+desired_count             = 1
+auto_scaling_min_capacity = 1
+auto_scaling_max_capacity = 1
 
 container_port=3500
 node_path="app/src"

--- a/terraform/vars/terraform-staging.tfvars
+++ b/terraform/vars/terraform-staging.tfvars
@@ -1,8 +1,11 @@
 environment               = "staging"
-logger_level                 = "info"
+logger_level              = "info"
+
+// Only ever have one replica running, otherwise multiple emails will be sent!
+// As multiple services will subscribe to the Redis channel
 desired_count             = 1
 auto_scaling_min_capacity = 1
-auto_scaling_max_capacity = 15
+auto_scaling_max_capacity = 1
 
 container_port=3500
 node_path="app/src"


### PR DESCRIPTION
Multiple emails were being sent in the production environment. 

This was because two replica services were running in production causing multiple subscribes to the [Redis queue](https://github.com/wri/fw_mail/blob/4c1842577b9f64fd013a6e38e75cb56b1e09b8ba/app/src/queues/mailQueue.js#L20).

This meant when the "message" event fired all these listeners would fire and send emails.

Only running one replica should be fine as this is a synchronous queue anyway.

[Support](https://3sidedcube.atlassian.net/browse/SP-870)